### PR TITLE
Device resource request tests updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ pip install -I pelion_test_lib*.whl
 ## Basic usage
 
 - Build the [Device Management Client example application](https://www.pelion.com/docs/device-management/current/connecting/device-management-client-tutorials.html) for your board and flash it.
-- [API key](https://www.pelion.com/docs/device-management/current/integrate-web-app/api-keys.html) is used from Mbed's default `CLOUD_SDK_API_KEY` environment variable, but you can override it by defining separate variable using following command-line command:
+- The [API key](https://www.pelion.com/docs/device-management/current/integrate-web-app/api-keys.html) is used from Mbed's default `CLOUD_SDK_API_KEY` environment variable, but you can override it by defining a separate variable using a command-line command:
     - Linux: `export PELION_CLOUD_API_KEY=[api_key_here]`
     - Windows: `set PELION_CLOUD_API_KEY=[api_key_here]`
 - Tests use [Mbed LS](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-ls) to select the board from the serial port.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Python 3.5 or later.
 
 ```bash
 $ git clone https://github.com/ArmMbed/pelion-e2e-python-test-library.git
+$ pip install wheel
 $ python3 setup.py bdist_wheel
 $ cd dist/
 $ pip install -I pelion_test_lib*.whl
@@ -18,8 +19,8 @@ $ pip install -I pelion_test_lib*.whl
 
 ## Basic usage
 
-- Build the [Device Management Client example application](https://github.com/ARMmbed/mbed-cloud-client-example) for your board and flash it.
-- Set your account's [API key](https://www.pelion.com/docs/device-management/current/integrate-web-app/api-keys.html) using following command-line command:
+- Build the [Device Management Client example application](https://www.pelion.com/docs/device-management/current/connecting/device-management-client-tutorials.html) for your board and flash it.
+- [API key](https://www.pelion.com/docs/device-management/current/integrate-web-app/api-keys.html) is used from Mbed's default `CLOUD_SDK_API_KEY` environment variable, but you can override it by defining separate variable using following command-line command:
     - Linux: `export PELION_CLOUD_API_KEY=[api_key_here]`
     - Windows: `set PELION_CLOUD_API_KEY=[api_key_here]`
 - Tests use [Mbed LS](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-ls) to select the board from the serial port.
@@ -37,7 +38,7 @@ $ mbedls
 
 ### Running a test set
 
-To run a test set for Device Management Client, go to `/tests` folder and use the command:
+To run a test set for Device Management Client, go to the `/tests` folder and use the command:
 
 ```bash
 pytest dev-client-tests.py -v -log_cli=true --log-cli-level=INFO --html=results.html
@@ -46,7 +47,7 @@ When the test run starts, reset the board to trigger the bootstrap.
 
 ### Running a single test
 
-To run a single test from the set, use [`-k` argument](https://docs.pytest.org/en/latest/example/markers.html?highlight=keyword#using-k-expr-to-select-tests-based-on-their-name) to set the test name as a keyword:
+To run a single test from the set, use the [`-k` argument](https://docs.pytest.org/en/latest/example/markers.html?highlight=keyword#using-k-expr-to-select-tests-based-on-their-name) to set the test name as a keyword:
 
 ```bash
 pytest dev-client-tests.py -v -log_cli=true --log-cli-level=INFO --html=results.html -k test_03_get_resource

--- a/pelion_test_lib/cloud/cloud.py
+++ b/pelion_test_lib/cloud/cloud.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pelion_test_lib/cloud/libraries/account.py
+++ b/pelion_test_lib/cloud/libraries/account.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pelion_test_lib/cloud/libraries/connect.py
+++ b/pelion_test_lib/cloud/libraries/connect.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -26,6 +26,20 @@ class ConnectAPI:
         """
         self.api_version = 'v2'
         self.cloud_api = rest_api
+
+    def send_device_request(self, device_id, request_data, request_params, headers=None, expected_status_code=None):
+        """
+        Send async request to device
+        :param device_id: Device id
+        :param request_data: Request payload data
+        :param request_params: Request parameters
+        :param headers: Override default header fields
+        :param expected_status_code: Asserts the result's status code
+        :return: POST /v2/device-requests/{device_id} response
+        """
+        api_url = '/{}/device-requests/{}'.format(self.api_version, device_id)
+        r = self.cloud_api.post(api_url, request_data, headers, expected_status_code, params=request_params)
+        return r
 
     def get_device_resource_value(self, device_id, resource_path, headers=None, expected_status_code=None):
         """

--- a/pelion_test_lib/cloud/libraries/device_directory.py
+++ b/pelion_test_lib/cloud/libraries/device_directory.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pelion_test_lib/cloud/libraries/rest_api/rest_api.py
+++ b/pelion_test_lib/cloud/libraries/rest_api/rest_api.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pelion_test_lib/fixtures/cloud_fixtures.py
+++ b/pelion_test_lib/fixtures/cloud_fixtures.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -30,8 +30,20 @@ def cloud():
     """
     log.debug("Initializing Cloud API fixture")
 
-    api_gw = os.getenv('PELION_CLOUD_API_GW', 'https://api.us-east-1.mbedcloud.com')
-    api_key = os.environ['PELION_CLOUD_API_KEY']
+    api_gw = os.environ.get('PELION_CLOUD_API_GW', 'https://api.us-east-1.mbedcloud.com')
+    if os.environ.get('PELION_CLOUD_API_KEY'):
+        api_key = os.environ.get('PELION_CLOUD_API_KEY')
+    else:
+        api_key = os.environ.get('CLOUD_SDK_API_KEY')
+
+    if not api_gw or not api_key:
+        pytest.exit('Set missing API gateway url and/or API key via environment variables before running tests!\n'
+                    'API GW: PELION_CLOUD_API_GW={}\n'
+                    'API KEY: CLOUD_SDK_API_KEY={} or '
+                    'PELION_CLOUD_API_KEY={}'.format(api_gw if api_gw != '' else 'MISSING!',
+                                                     os.environ.get('CLOUD_SDK_API_KEY', 'MISSING!'),
+                                                     os.environ.get('PELION_CLOUD_API_KEY', 'MISSING!')))
+
     cloud_api = PelionCloud(api_gw, api_key)
 
     payload = {'name': 'pelion_e2e_dynamic_api_key'}

--- a/pelion_test_lib/helpers/connect_helper.py
+++ b/pelion_test_lib/helpers/connect_helper.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2019 ARM Limited
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import base64
+import json
+import logging
+import uuid
+
+logging.basicConfig(format="%(asctime)s:%(name)s:%(threadName)s:%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+def get_async_device_request(cloud, path, device_id, headers):
+    """
+    Sends GET async request to device
+    https://www.pelion.com/docs/device-management/current/service-api-references/device-management-connect.html#createAsyncRequest
+    :param cloud: Cloud object
+    :param path: Device resource path
+    :param device_id: Device ID
+    :param headers: Request headers
+    :return: Async_id
+    """
+    async_id = str(uuid.uuid4())
+    request_params = {'async-id': async_id}
+    request_payload = {'method': 'GET', 'uri': path}
+    cloud.connect.send_device_request(device_id, json.dumps(request_payload), request_params, headers=headers,
+                                      expected_status_code=202)
+    return async_id
+
+
+def put_async_device_request(cloud, path, device_id, request_data, headers, content_type="text/plain"):
+    """
+    Sends PUT async request to device
+    https://www.pelion.com/docs/device-management/current/service-api-references/device-management-connect.html#createAsyncRequest
+    :param cloud: Cloud object
+    :param path: Device resource path
+    :param device_id: Device ID
+    :param request_data: Data sent to resource path
+    :param headers: Request headers
+    :param content_type: Data content type
+    :return: Async_id
+    """
+    async_id = str(uuid.uuid4())
+    payload_data = base64.b64encode(str.encode(request_data)).decode()
+    request_params = {"async-id": async_id}
+    request_payload = {"method": "PUT", "uri": path, "content-type": content_type,
+                       "payload-b64": payload_data}
+    cloud.connect.send_device_request(device_id, json.dumps(request_payload), request_params, headers=headers,
+                                      expected_status_code=202)
+    return async_id

--- a/pelion_test_lib/helpers/websocket_handler.py
+++ b/pelion_test_lib/helpers/websocket_handler.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pelion_test_lib/tools/client_runner.py
+++ b/pelion_test_lib/tools/client_runner.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pelion_test_lib/tools/external_conn.py
+++ b/pelion_test_lib/tools/external_conn.py
@@ -1,0 +1,138 @@
+"""
+Copyright 2019 ARM Limited
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import json
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+class ExternalConnection:
+    def __init__(self, importer=__import__):
+        self.client = None
+        self.resource = None
+        self.__initialize_resource(importer)
+
+    def __initialize_resource(self, importer):
+        """
+        Connect to external resource and flash it
+        """
+        try:
+            with open('external_connection.json', 'r') as config_file:
+                configs = json.load(config_file)
+        except IOError:
+            error_msg = 'Could not load the external connection configs'
+            log.error(error_msg)
+            raise Exception(error_msg)
+
+        external_module = configs['module']
+        host = configs['host']
+        port = configs['port']
+        user = configs['user']
+        password = configs['password']
+        resource_type = configs['resource_type']
+        platform_name = configs['platform_name']
+        resource_tags = configs['resource_tags']
+        binary = configs['binary']
+        baudrate = configs['baudrate']
+        expiration_time = configs.get('expiration_time', 1200)
+        allocation_timeout = configs.get('allocation_timeout', 500)
+        local_allocation = configs.get('local_allocation', False)
+
+        try:
+            self.remote_module = importer(external_module)
+        except ImportError as error:
+            log.error('Unable to load external "{}" module!'.format(external_module))
+            log.error(str(error))
+            self.remote_module = None
+            raise error
+
+        self.client = self.remote_module.create(host=host, port=port, logger=log, user=user, passwd=password)
+
+        description = {'resource_type': resource_type,
+                       'platform_name': platform_name,
+                       'tags': resource_tags}
+        self.resource = self.client.allocate(description, expiration_time, allocation_timeout, local_allocation)
+        if self.resource:
+            self.resource.open_connection(self.remote_module.SerialParameters(baudrate=baudrate))
+            self.resource.on_release('erase')
+            self.flash(binary, force_flash=True)
+        else:
+            self.close()
+            error_msg = 'Could not allocate external resource'
+            log.error(error_msg)
+            assert False, error_msg
+
+    def readline(self):
+        """
+        Read line
+        :return: One line from serial stream
+        """
+        try:
+            if self.resource:
+                output = self.resource.readline()
+                return output
+            else:
+                raise Exception('External resource does not exist')
+        except Exception as ex:
+            log.debug('External connection read error: {}'.format(ex))
+            return None
+
+    def write(self, data):
+        """
+        Write data
+        :param data: Data to send
+        """
+        try:
+            if self.resource:
+                self.resource.write(data)
+            else:
+                raise Exception('External resource does not exist')
+        except Exception as ex:
+            log.debug('External connection write error: {}'.format(ex))
+
+    def reset(self):
+        """
+        Reset resource
+        """
+        try:
+            if self.resource:
+                self.resource.reset()
+            else:
+                raise Exception('External resource does not exist')
+        except Exception as ex:
+            log.debug('External connection reset error: {}'.format(ex))
+
+    def flash(self, filename, force_flash=False):
+        """
+        Flash resource
+        :param filename: Path to binary
+        :param force_flash: Force flash True/False
+        """
+        try:
+            if self.resource:
+                self.resource.flash(filename, forceflash=force_flash)
+            else:
+                raise Exception('External resource does not exist')
+        except Exception as ex:
+            log.debug('External connection flash error: {}'.format(ex))
+
+    def close(self):
+        """
+        Close connection
+        """
+        if self.resource:
+            self.resource.release()
+        if self.client:
+            self.client.disconnect()

--- a/pelion_test_lib/tools/serial_conn.py
+++ b/pelion_test_lib/tools/serial_conn.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pelion_test_lib/tools/utils.py
+++ b/pelion_test_lib/tools/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -22,6 +22,9 @@ PACKAGE_LIST = ['pelion_test_lib',
                 'pelion_test_lib.helpers',
                 'pelion_test_lib.tools']
 
+AUTHORS = 'Jani Simonen'
+AUTHOR_EMAILS = 'jani.simonen@arm.com'
+
 with open('requirements.txt') as f:
     required = f.read().splitlines()
 
@@ -29,9 +32,11 @@ setup(name=PACKAGE_NAME,
       use_scm_version={'root': '.'},
       setup_requires=['setuptools_scm==3.2.0'],
       description="Pelion E2E Python Test Library",
-      author="systest",
-      author_email="iot-systestteam-testing@arm.com",
+      author=AUTHORS,
+      author_email=AUTHOR_EMAILS,
+      maintainer=AUTHORS,
+      maintainer_email=AUTHOR_EMAILS,
       url="git@github.com:ArmMbedCloud/pelion-e2e-python-test-library.git",
-      license="proprietary",
+      license="Apache-2.0",
       packages=PACKAGE_LIST,
       install_requires=required)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -25,3 +25,4 @@ def pytest_addoption(parser):
     """
     parser.addoption('--target_id', action='store', help='mbed device target id')
     parser.addoption('--update_bin', action='store', help='mbed device update binary')
+    parser.addoption('--ext_conn', action='store_true', default=False, help='use external connection')

--- a/tests/dev-client-tests.py
+++ b/tests/dev-client-tests.py
@@ -1,5 +1,5 @@
 """
-Copyright 2017 ARM Limited
+Copyright 2019 ARM Limited
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -12,13 +12,14 @@ limitations under the License.
 """
 
 import logging
+from pelion_test_lib.helpers.connect_helper import get_async_device_request, put_async_device_request
 
 logging.basicConfig(format="%(asctime)s:%(name)s:%(threadName)s:%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 PATTERN = '1:2:3:4'
-RESOURCE_PATH = '3201/0/5853'
+RESOURCE_PATH = '/3201/0/5853'
 
 
 def test_01_get_device_id(cloud, client):
@@ -34,8 +35,7 @@ def test_02_subscribe_resource(cloud, client):
 
 def test_03_get_resource(cloud, client, websocket, temp_api_key):
     headers = {'Authorization': 'Bearer {}'.format(temp_api_key['key'])}
-    r = cloud.connect.get_device_resource_value(client.endpoint_id(), RESOURCE_PATH, headers=headers)
-    async_id = r.json()['async-response-id']
+    async_id = get_async_device_request(cloud, RESOURCE_PATH, client.endpoint_id(), headers)
     log.info('Get value from resource "{}". Async-id: "{}"'.format(RESOURCE_PATH, async_id))
 
     async_response = websocket.wait_for_async_response(async_response_id=async_id, timeout=30, assert_errors=True)
@@ -43,9 +43,8 @@ def test_03_get_resource(cloud, client, websocket, temp_api_key):
 
 
 def test_04_put_resource(cloud, client, websocket, temp_api_key):
-    headers = {'Authorization': 'Bearer {}'.format(temp_api_key['key']), 'Content-type': 'text/plain'}
-    r = cloud.connect.set_device_resource_value(client.endpoint_id(), RESOURCE_PATH, PATTERN, headers=headers)
-    async_id = r.json()['async-response-id']
+    headers = {'Authorization': 'Bearer {}'.format(temp_api_key['key'])}
+    async_id = put_async_device_request(cloud, RESOURCE_PATH, client.endpoint_id(), PATTERN, headers)
     log.info('Put value "{}" to resource "{}". Async-id: "{}"'.format(PATTERN, RESOURCE_PATH, async_id))
 
     client.wait_for_output('PUT received, new value: {}'.format(PATTERN).encode('ascii'), 60)
@@ -55,10 +54,8 @@ def test_04_put_resource(cloud, client, websocket, temp_api_key):
 
 def test_05_get_modified_resource(cloud, client, websocket, temp_api_key):
     headers = {'Authorization': 'Bearer {}'.format(temp_api_key['key'])}
-    r = cloud.connect.get_device_resource_value(client.endpoint_id(), RESOURCE_PATH, headers=headers)
-    async_id = r.json()['async-response-id']
+    async_id = get_async_device_request(cloud, RESOURCE_PATH, client.endpoint_id(), headers)
     log.info('Get value from resource "{}". Async-id: "{}"'.format(RESOURCE_PATH, async_id))
 
     async_response = websocket.wait_for_async_response(async_response_id=async_id, timeout=30, assert_errors=True)
-    assert async_response['decoded_payload'] == PATTERN.encode('ascii'), \
-        'Invalid payload received from the device!'
+    assert async_response['decoded_payload'] == PATTERN.encode('ascii'), 'Invalid payload received from the device!'


### PR DESCRIPTION
- Tests changed to use device-requests
- CLOUD_SDK_API_KEY is now used as default, overrideable with PELION_CLOUD_API_KEY
- Added external connection module